### PR TITLE
Fix Toolkit Page Layout and Update Toolkit Links

### DIFF
--- a/app/learn/toolkit/page.tsx
+++ b/app/learn/toolkit/page.tsx
@@ -1,10 +1,6 @@
-import { DashboardLayoutMinimal } from "@/components/dashboard/dashboard-layout-minimal"
-import { AIToolkit } from "@/components/toolkit/ai-toolkit"
+import { redirect } from "next/navigation"
 
 export default function ToolkitPage() {
-  return (
-    <DashboardLayoutMinimal>
-      <AIToolkit />
-    </DashboardLayoutMinimal>
-  )
+  // Consolidate toolkit routes: redirect to unified page
+  redirect("/toolkit")
 }

--- a/components/dashboard/dashboard-layout-minimal.tsx
+++ b/components/dashboard/dashboard-layout-minimal.tsx
@@ -44,7 +44,7 @@ const navigation = [
   { name: "Learning", href: "/learn/learning", icon: GraduationCap },
   { name: "Playground", href: "/learn/playground", icon: Target },
   { name: "Analytics", href: "/learn/analytics", icon: BarChart3 },
-  { name: "Toolkit", href: "/learn/toolkit", icon: Wrench },
+  { name: "Toolkit", href: "/toolkit", icon: Wrench },
   { name: "Discussion", href: "/learn/discussion", icon: MessageSquare },
   { name: "Resources", href: "/learn/resources", icon: FileText },
   { name: "Certificates", href: "/learn/certificates", icon: Award },

--- a/components/landing/harka-hero.tsx
+++ b/components/landing/harka-hero.tsx
@@ -445,7 +445,7 @@ export function HarkaHero() {
               <Link href="/learn/analytics" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
                 Analytics
               </Link>
-              <Link href="/learn/toolkit" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
+              <Link href="/toolkit" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
                 Toolkit
               </Link>
               {isAdmin && (
@@ -555,7 +555,7 @@ export function HarkaHero() {
               <Link href="/learn/analytics" className="block px-3 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">
                 Analytics
               </Link>
-              <Link href="/learn/toolkit" className="block px-3 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">
+              <Link href="/toolkit" className="block px-3 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">
                 Toolkit
               </Link>
               {isAdmin && (


### PR DESCRIPTION
## Summary
- Redirects `/learn/toolkit` route to unified `/toolkit` page
- Updates navigation and landing page links to point to `/toolkit` instead of `/learn/toolkit`
- Removes redundant layout wrapper from Toolkit page

## Changes

### Routing and Page Layout
- Modified `app/learn/toolkit/page.tsx` to redirect to `/toolkit` instead of rendering Toolkit component inside minimal dashboard layout

### Navigation Updates
- Changed Toolkit navigation link in `DashboardLayoutMinimal` from `/learn/toolkit` to `/toolkit`

### Landing Page Updates
- Updated all Toolkit links in `HarkaHero` component to point to `/toolkit` instead of `/learn/toolkit`

## Test plan
- [x] Verify that navigating to `/learn/toolkit` redirects to `/toolkit`
- [x] Confirm that Toolkit links in dashboard navigation and landing page direct to `/toolkit`
- [x] Check that the Toolkit page renders correctly at `/toolkit` without layout issues
- [x] Ensure no broken links or navigation errors related to Toolkit routes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8f4c668e-e916-46f6-bf81-c458789f046f